### PR TITLE
add support for new phao-mqtt CallBackAPI

### DIFF
--- a/mqtt_co2monitor.py
+++ b/mqtt_co2monitor.py
@@ -10,8 +10,13 @@ import time
 from module import secrets
 import sys, fcntl, time
 
-mqttBroker ="mosquitfoo.example.com" 
-client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, "raspi-desk")
+mqttBroker ="mosquitfoo.example.com"
+clientname ="raspi-desk"
+try:
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, clientname)
+except:
+    client = mqtt.Client(clientname)
+
 client.username_pw_set(username = secrets.username, password = secrets.password)
 client.tls_set(ca_certs='/etc/ssl/certs/ca-certificates.crt')
 client.clean_session = True

--- a/mqtt_co2monitor.py
+++ b/mqtt_co2monitor.py
@@ -11,7 +11,7 @@ from module import secrets
 import sys, fcntl, time
 
 mqttBroker ="mosquitfoo.example.com" 
-client = mqtt.Client("raspi-desk")
+client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, "raspi-desk")
 client.username_pw_set(username = secrets.username, password = secrets.password)
 client.tls_set(ca_certs='/etc/ssl/certs/ca-certificates.crt')
 client.clean_session = True


### PR DESCRIPTION
Hi,

this adds Support to the new V2 CallBackAPI of phao-mqtt which ships with Debian13 (as an example), while maintaining compatible with the older version.

Cheers